### PR TITLE
Additional object support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# 1.1
+
+The debugger will now report the content of objects of the following types:
+ - `org.json.JSONObject`
+ - `org.json.JSONArray`
+ - `com.thingworx.dsl.engine.adapters.JSONArrayAdapter`
+ - `com.thingworx.dsl.engine.adapters.JSONObjectAdapter`
+ - `com.thingworx.dsl.engine.adapters.ThingworxInfoTableAdapter`
+ - `com.thingworx.metadata.DataShapeDefinition`
+ - `com.thingworx.metadata.collections.FieldDefinitionCollection`
+ - `com.thingworx.metadata.FieldDefinition`
+ - `com.thingworx.types.collections.AspectCollection`
+ - `com.thingworx.types.BaseTypes`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bm-thingworx-debug-server",
 	"packageName": "bm-thingworx-debug-server",
 	"moduleName": "bm-thingworx-debug-server",
-	"version": "1.0.0-beta.1",
+	"version": "1.1.0",
 	"description": "Debug projects created using ThingworxVSCodeProject.",
 	"author": "Bogdan Mihaiciuc",
 	"thingworxProjectName": "BMDebugServer",


### PR DESCRIPTION
Adds support for the following object kinds:
 - `org.json.JSONObject`
 - `org.json.JSONArray`
 - `com.thingworx.dsl.engine.adapters.JSONArrayAdapter`
 - `com.thingworx.dsl.engine.adapters.JSONObjectAdapter`
 - `com.thingworx.dsl.engine.adapters.ThingworxInfoTableAdapter`
 - `com.thingworx.metadata.DataShapeDefinition`
 - `com.thingworx.metadata.collections.FieldDefinitionCollection`
 - `com.thingworx.metadata.FieldDefinition`
 - `com.thingworx.types.collections.AspectCollection`
 - `com.thingworx.types.BaseTypes`