### PR TITLE
Exception improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.2
+
+Resolves an issue that caused thrown value details to not be correctly reported on Thingworx 9.3.4 or later.
+
+Resolves an issue where the filename of global functions was not properly reported.
+
+Adds support for breaking only on caught or uncaught thrown values in addition to any thrown values.
+
+After continuing following a break on an exception, the debugger will no longer stop for each subsequent service on that same exception.
+
 # 1.1.1
 
 Compatibility with Thingworx 9.3.4. This release should not be used on prior versions of Thingworx.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bm-thingworx-debug-server",
 	"packageName": "bm-thingworx-debug-server",
 	"moduleName": "bm-thingworx-debug-server",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "Debug projects created using ThingworxVSCodeProject.",
 	"author": "Bogdan Mihaiciuc",
 	"thingworxProjectName": "BMDebugServer",

--- a/src/BMDebugServer.ts
+++ b/src/BMDebugServer.ts
@@ -226,10 +226,14 @@
 
     /**
      * Sets whether the debugger should automatically break when an exception is thrown.
-     * @param breaks    `true` if the debugger should suspend when an exception is thrown, `false` otherwise.
+     * @param breaks                `true` if the debugger should suspend when an exception is thrown, `false` otherwise.
+     * @param caughtExceptions      `true` if the debugger should suspend when an exception is thrown and caught, `false` otherwise.
+     * @param uncaughtExceptions    `true` if the debugger should suspend when an exception is thrown and not caught, `false` otherwise.
      */
-    setBreakOnExceptions({breaks}: {breaks: boolean}): void {
+    setBreakOnExceptions({breaks, caughtExceptions, uncaughtExceptions}: {breaks: boolean, caughtExceptions: boolean, uncaughtExceptions: boolean}): void {
         BMDebuggerRuntime.breaksOnException = breaks;
+        BMDebuggerRuntime.breaksOnCaughtException = caughtExceptions;
+        BMDebuggerRuntime.breaksOnUncaughtException = uncaughtExceptions;
     }
 
     /**

--- a/src/debugserver-impl/BMDebuggerSupport.ts
+++ b/src/debugserver-impl/BMDebuggerSupport.ts
@@ -46,6 +46,11 @@ interface BMDebuggerServiceScope {
      * The name of the function.
      */
     name: string;
+
+    /**
+     * The name of the file in which this function was originally defined.
+     */
+    filename: string;
 }
 
 


### PR DESCRIPTION
Resolves an issue that caused thrown value details to not be correctly reported on Thingworx 9.3.4 or later.

Resolves an issue where the filename of global functions was not properly reported.

Adds support for breaking only on caught or uncaught thrown values in addition to any thrown values.

After continuing following a break on an exception, the debugger will no longer stop for each subsequent service on that same exception.